### PR TITLE
Refactor headhunter data to use shared highlights

### DIFF
--- a/resume/src/data/headhunter/sre-devops-en.ts
+++ b/resume/src/data/headhunter/sre-devops-en.ts
@@ -1,6 +1,7 @@
 import * as personal from '../common/personal';
 import * as en from '../common/sre-devops-en';
 import { HeadhunterResumeInfo } from './types';
+import { workToHeadhunterExperience } from './utils';
 
 export const resume: HeadhunterResumeInfo = {
   resumeId: '59b9dc79ff09cc48d80039ed1f7864386c7758',
@@ -24,66 +25,13 @@ export const resume: HeadhunterResumeInfo = {
         },
       ],
       experience: [
-        {
-          start: en.data.work.freelance.startDate + '-01',
-          company: en.data.work.freelance.name,
-          position: en.data.work.freelance.position,
-          industries: [],
-          description: en.data.work.freelance.summary,
-        },
-        {
-          start: en.data.work.amarkets.startDate + '-01',
-          end: en.data.work.amarkets.endDate + '-01',
-          company: en.data.work.amarkets.name,
-          position: en.data.work.amarkets.position,
-          industries: [],
-          description: en.data.work.amarkets.summary,
-        },
-        {
-          company_url: en.data.work.gaijin.website,
-          start: en.data.work.gaijin.startDate + '-01',
-          end: en.data.work.gaijin.endDate + '-01',
-          company: en.data.work.gaijin.name,
-          position: en.data.work.gaijin.position,
-          industries: [],
-          description: en.data.work.gaijin.summary,
-        },
-        {
-          company_url: en.data.work.yandex.website,
-          start: en.data.work.yandex.startDate + '-01',
-          end: en.data.work.yandex.endDate + '-01',
-          company: en.data.work.yandex.name,
-          position: en.data.work.yandex.position,
-          industries: [],
-          description: en.data.work.yandex.summary,
-        },
-        {
-          company_url: en.data.work.rostelecom.website,
-          start: en.data.work.rostelecom.startDate + '-01',
-          end: en.data.work.rostelecom.endDate + '-01',
-          company: en.data.work.rostelecom.name,
-          position: en.data.work.rostelecom.position,
-          industries: [],
-          description: en.data.work.rostelecom.summary,
-        },
-        {
-          company_url: en.data.work.equilibrium.website,
-          start: en.data.work.equilibrium.startDate + '-01',
-          end: en.data.work.equilibrium.endDate + '-01',
-          company: en.data.work.equilibrium.name,
-          position: en.data.work.equilibrium.position,
-          industries: [],
-          description: en.data.work.equilibrium.summary,
-        },
-        {
-          company_url: en.data.work.restream.website,
-          start: en.data.work.restream.startDate + '-01',
-          end: en.data.work.restream.endDate + '-01',
-          company: en.data.work.restream.name,
-          position: en.data.work.restream.position,
-          industries: [],
-          description: en.data.work.restream.summary,
-        },
+        workToHeadhunterExperience(en.data.work.freelance),
+        workToHeadhunterExperience(en.data.work.amarkets),
+        workToHeadhunterExperience(en.data.work.gaijin),
+        workToHeadhunterExperience(en.data.work.yandex),
+        workToHeadhunterExperience(en.data.work.rostelecom),
+        workToHeadhunterExperience(en.data.work.equilibrium),
+        workToHeadhunterExperience(en.data.work.restream),
       ],
       languages: [en.data.languages.russian, en.data.languages.english],
       certificate: [en.data.certificates.cka, en.data.certificates.cks],

--- a/resume/src/data/headhunter/sre-devops-ru.ts
+++ b/resume/src/data/headhunter/sre-devops-ru.ts
@@ -1,6 +1,7 @@
 import * as personal from '../common/personal';
 import * as ru from '../common/sre-devops-ru';
 import { HeadhunterResumeInfo } from './types';
+import { workToHeadhunterExperience } from './utils';
 
 export const resume: HeadhunterResumeInfo = {
   resumeId: 'a22559aeff0d608b840039ed1f4c4137784e4a',
@@ -24,66 +25,13 @@ export const resume: HeadhunterResumeInfo = {
         },
       ],
       experience: [
-        {
-          start: ru.data.work.freelance.startDate + '-01',
-          company: ru.data.work.freelance.name,
-          position: ru.data.work.freelance.position,
-          industries: [],
-          description: ru.data.work.freelance.summary,
-        },
-        {
-          start: ru.data.work.amarkets.startDate + '-01',
-          end: ru.data.work.amarkets.endDate + '-01',
-          company: ru.data.work.amarkets.name,
-          position: ru.data.work.amarkets.position,
-          industries: [],
-          description: ru.data.work.amarkets.summary,
-        },
-        {
-          company_url: ru.data.work.gaijin.website,
-          start: ru.data.work.gaijin.startDate + '-01',
-          end: ru.data.work.gaijin.endDate + '-01',
-          company: ru.data.work.gaijin.name,
-          position: ru.data.work.gaijin.position,
-          industries: [],
-          description: ru.data.work.gaijin.summary,
-        },
-        {
-          company_url: ru.data.work.yandex.website,
-          start: ru.data.work.yandex.startDate + '-01',
-          end: ru.data.work.yandex.endDate + '-01',
-          company: ru.data.work.yandex.name,
-          position: ru.data.work.yandex.position,
-          industries: [],
-          description: ru.data.work.yandex.summary,
-        },
-        {
-          company_url: ru.data.work.rostelecom.website,
-          start: ru.data.work.rostelecom.startDate + '-01',
-          end: ru.data.work.rostelecom.endDate + '-01',
-          company: ru.data.work.rostelecom.name,
-          position: ru.data.work.rostelecom.position,
-          industries: [],
-          description: ru.data.work.rostelecom.summary,
-        },
-        {
-          company_url: ru.data.work.equilibrium.website,
-          start: ru.data.work.equilibrium.startDate + '-01',
-          end: ru.data.work.equilibrium.endDate + '-01',
-          company: ru.data.work.equilibrium.name,
-          position: ru.data.work.equilibrium.position,
-          industries: [],
-          description: ru.data.work.equilibrium.summary,
-        },
-        {
-          company_url: ru.data.work.restream.website,
-          start: ru.data.work.restream.startDate + '-01',
-          end: ru.data.work.restream.endDate + '-01',
-          company: ru.data.work.restream.name,
-          position: ru.data.work.restream.position,
-          industries: [],
-          description: ru.data.work.restream.summary,
-        },
+        workToHeadhunterExperience(ru.data.work.freelance),
+        workToHeadhunterExperience(ru.data.work.amarkets),
+        workToHeadhunterExperience(ru.data.work.gaijin),
+        workToHeadhunterExperience(ru.data.work.yandex),
+        workToHeadhunterExperience(ru.data.work.rostelecom),
+        workToHeadhunterExperience(ru.data.work.equilibrium),
+        workToHeadhunterExperience(ru.data.work.restream),
       ],
       languages: [ru.data.languages.russian, ru.data.languages.english],
       certificate: [ru.data.certificates.cka, ru.data.certificates.cks],

--- a/resume/src/data/headhunter/types.ts
+++ b/resume/src/data/headhunter/types.ts
@@ -1,3 +1,13 @@
+export type HeadhunterExperience = {
+  start: string;
+  end?: string;
+  company: string;
+  company_url?: string;
+  position: string;
+  industries: unknown[];
+  description: string[];
+};
+
 export type HeadhunterResumeInfo = {
   resumeId: string;
   data: string;

--- a/resume/src/data/headhunter/utils.ts
+++ b/resume/src/data/headhunter/utils.ts
@@ -1,0 +1,38 @@
+import { Work } from '../common/types';
+import { HeadhunterExperience } from './types';
+
+const ensureHeadHunterDate = (value: string): string =>
+  value.length === 7 ? `${value}-01` : value;
+
+const buildDescriptionList = (work: Work): string[] => {
+  const items: string[] = [];
+
+  const summary = work.summary?.trim();
+  if (summary) {
+    items.push(summary);
+  }
+
+  const highlights = work.highlights
+    ?.map((highlight) => highlight.trim())
+    .filter((highlight) => highlight.length > 0);
+
+  if (highlights && highlights.length > 0) {
+    items.push(...highlights);
+  }
+
+  return items;
+};
+
+export const workToHeadhunterExperience = (
+  work: Work,
+): HeadhunterExperience => {
+  return {
+    company: work.name,
+    position: work.position,
+    industries: [],
+    description: buildDescriptionList(work),
+    start: ensureHeadHunterDate(work.startDate),
+    ...(work.endDate ? { end: ensureHeadHunterDate(work.endDate) } : {}),
+    ...(work.website ? { company_url: work.website } : {}),
+  };
+};


### PR DESCRIPTION
## Summary
- add a shared helper for converting common work entries into HeadHunter experience objects that carry highlight lists
- update the English and Russian HeadHunter resume payloads to reuse the helper so experience descriptions leverage the common highlights
- define a dedicated HeadHunter experience type for stronger typing of the generated payload

## Testing
- npm run build:website-resume

------
https://chatgpt.com/codex/tasks/task_e_68ca808bd248832f83bd5e2888effbbb