### PR TITLE
Add health probes for GCS proxy Cloud Run service

### DIFF
--- a/infra/gcp/gcs-proxy.ts
+++ b/infra/gcp/gcs-proxy.ts
@@ -38,13 +38,25 @@ export function Deploy(project: string, region: string, image: string) {
                   name: 'http1',
                 },
               ],
+              livenessProbe: {
+                httpGet: {
+                  path: '/resume.html',
+                  port: 8080,
+                },
+              },
+              readinessProbe: {
+                httpGet: {
+                  path: '/resume.html',
+                  port: 8080,
+                },
+              },
               resources: {
                 limits: {
                   cpu: '1',
                   memory: '128Mi',
                 },
               },
-            },
+            } as gcp.types.input.cloudrun.ServiceTemplateSpecContainer,
           ],
           timeoutSeconds: 300,
         },


### PR DESCRIPTION
## Summary
- add HTTP liveness and readiness probes for `/resume.html` on the Cloud Run GCS proxy container

## Testing
- yarn tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68ca9c1056ec832f98e5fa57f3cc3cd6